### PR TITLE
Get genesis block from lotus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,11 +57,6 @@ COPY --from=build-env /usr/bin/jq /usr/bin/
 COPY config/config.toml /root/config.toml
 COPY scripts/entrypoint scripts/healthcheck /bin/
 
-ADD https://raw.githubusercontent.com/filecoin-project/network-info/master/static/networks/butterfly.json /networks/
-ADD https://raw.githubusercontent.com/filecoin-project/network-info/master/static/networks/calibration.json /networks/
-ADD https://raw.githubusercontent.com/filecoin-project/network-info/master/static/networks/mainnet.json /networks/
-ADD https://raw.githubusercontent.com/filecoin-project/network-info/master/static/networks/nerpa.json /networks/
-
 # API port
 EXPOSE 1234/tcp
 

--- a/scripts/healthcheck
+++ b/scripts/healthcheck
@@ -3,7 +3,7 @@
 ALLOWED_DELAY=${ALLOWED_DELAY:=10}
 BLOCK_TIME=$(cat /networks/${NETWORK}.json | jq .NetworkParameters.EpochDurationSeconds -r)
 
-GENESIS_TIMESTAMP=$(date +"%s" -d $(cat /networks/${NETWORK}.json | jq .Genesis.Timestamp -r))
+GENESIS_TIMESTAMP=$(lotus chain getblock $(lotus chain list --count 1 --height 0 --format="<tipset>") | jq .Timestamp -r)
 CURRENT_TIMESTAMP=$(date +"%s")
 DIFFERENCE_IN_TIME=$(( $CURRENT_TIMESTAMP - $GENESIS_TIMESTAMP ))
 MIN_ALLOWED_BLOCK=$(( $DIFFERENCE_IN_TIME / $BLOCK_TIME - $ALLOWED_DELAY ))


### PR DESCRIPTION
We have faced an issue with JSON genesis files being not updated in time for the test networks. According to https://github.com/orgs/protofire/projects/5 there's a way to fix it - check genesis block time from Lotus itself, and not from the external JSON files.