### PR TITLE
Script stucks on Lotus command execution

### DIFF
--- a/scripts/healthcheck
+++ b/scripts/healthcheck
@@ -3,14 +3,14 @@
 ALLOWED_DELAY=${ALLOWED_DELAY:=10}
 BLOCK_TIME=$(cat /networks/${NETWORK}.json | jq .NetworkParameters.EpochDurationSeconds -r)
 
-GENESIS_TIMESTAMP=$(lotus chain getblock $(lotus chain list --count 1 --height 0 --format="<tipset>") | jq .Timestamp -r)
+GENESIS_TIMESTAMP=$(timeout -k3 3 lotus chain getblock $(timeout -k3 3 lotus chain list --count 1 --height 0 --format="<tipset>") | jq .Timestamp -r)
 CURRENT_TIMESTAMP=$(date +"%s")
 DIFFERENCE_IN_TIME=$(( $CURRENT_TIMESTAMP - $GENESIS_TIMESTAMP ))
 MIN_ALLOWED_BLOCK=$(( $DIFFERENCE_IN_TIME / $BLOCK_TIME - $ALLOWED_DELAY ))
 OUR_BLOCK=$(curl -s --max-time 3 localhost:1234/debug/metrics | grep ^lotus_chain_node_worker_height | awk '{print $2}')
 
-# If local block is lower than minimum allowed block - the health is bad
-if [[ $OUR_BLOCK -ge $MIN_ALLOWED_BLOCK ]]; then
+# If local block is lower than minimum allowed block or we can't get block data - the health is bad
+if [[ "$OUR_BLOCK" -ge "$MIN_ALLOWED_BLOCK" && ! -z "$OUR_BLOCK" && ! -z "$MIN_ALLOWED_BLOCK" ]]; then
   exit 0
 else 
   exit 1


### PR DESCRIPTION
After recent update of healthcheck we haven't taken into the account that the Lotus CLI can simply stuck forever and this might cause the false-positive healthcheck. This timeouts wrappers should resolve the issue.