### PR TITLE
added Dockerfile for sync-s3-marketdeals CronJob container

### DIFF
--- a/sync-s3-marketdeals/Dockerfile
+++ b/sync-s3-marketdeals/Dockerfile
@@ -1,0 +1,34 @@
+FROM alpine:3.14
+
+ENV GLIBC_VER=2.34-r0
+
+# install glibc compatibility for alpine
+# more info - https://stackoverflow.com/questions/60298619/awscli-version-2-on-alpine-linux
+RUN apk --no-cache add \
+        binutils=2.35.2-r2 \
+        curl=7.79.1-r0 \
+        jq=1.6-r1 \
+    && curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-${GLIBC_VER}.apk \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-i18n-${GLIBC_VER}.apk \
+    && apk add --no-cache \
+        glibc-${GLIBC_VER}.apk \
+        glibc-bin-${GLIBC_VER}.apk \
+        glibc-i18n-${GLIBC_VER}.apk \
+    && /usr/glibc-compat/bin/localedef -i en_US -f UTF-8 en_US.UTF-8 \
+    && curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip \
+    && unzip awscliv2.zip \
+    && aws/install \
+    && rm -rf \
+        awscliv2.zip \
+    # we need aws folder in container, thus deleting only content
+        aws/* \
+        /usr/local/aws-cli/v2/current/dist/aws_completer \
+        /usr/local/aws-cli/v2/current/dist/awscli/data/ac.index \
+        /usr/local/aws-cli/v2/current/dist/awscli/examples \
+        glibc-*.apk \
+    && find /usr/local/aws-cli/v2/current/dist/awscli/botocore/data -name examples-1.json -delete \
+    && apk --no-cache del \
+        binutils \
+    && rm -rf /var/cache/apk/*


### PR DESCRIPTION
`sync-s3-marketdeals` CronJob is used for the heavy Filecoin.StateMarketDeals operation.
For some reason, the docker image wasn't in the docker registry and Dockerfile wasn't available thus I've created it from scratch using alpine Linux, some googling, and [hadolint](https://github.com/hadolint/hadolint) for the linting.

The following steps will be:
* add build of this image to our Jenkins
* add manifest of cronJon to helm charts repo
* remove StateMarketDeals from allowed public API method(rn it produces 500 or timeouts after calling due to amazon Gateway Limitations)
* add a link to S3 StateMarketDeals to the openworklabbot HTML page. 